### PR TITLE
patch: Test npm trusted publishing with NPM_TOKEN

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   flowzone:
     name: Flowzone
-    uses: product-os/flowzone/.github/workflows/flowzone.yml@master
+    uses: product-os/flowzone/.github/workflows/flowzone.yml@ab77/Create-OIDC-trust-between-npm-and-GitHub-Actions-2091
     # prevent duplicate workflow executions for pull_request and pull_request_target
     if: |
       (

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   id-token: write  # https://docs.npmjs.com/trusted-publishers
 
 jobs:

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -9,11 +9,6 @@ on:
     types: [opened, synchronize, closed]
     branches: [main, master]
 
-permissions:
-  contents: read
-  packages: read
-  id-token: write  # https://docs.npmjs.com/trusted-publishers
-
 jobs:
   flowzone:
     name: Flowzone

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -10,6 +10,7 @@ on:
     branches: [main, master]
 
 permissions:
+  contents: read
   id-token: write  # https://docs.npmjs.com/trusted-publishers
 
 jobs:

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -9,6 +9,9 @@ on:
     types: [opened, synchronize, closed]
     branches: [main, master]
 
+permissions:
+  id-token: write  # https://docs.npmjs.com/trusted-publishers
+
 jobs:
   flowzone:
     name: Flowzone

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   ],
   "author": "Thodoris Greasidis <thodoris@balena.io>",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=24.11.0 <25"
+  },
   "bugs": {
     "url": "https://github.com/balena-io-modules/git-rebase-branches/issues"
   },


### PR DESCRIPTION
> can be closed without merging after https://balena.fibery.io/Work/Project/Create-OIDC-trust-between-npm-and-GitHub-Actions-2091 testing is complete

Testing: https://github.com/product-os/flowzone/pull/1667